### PR TITLE
feat(plugin): migrate automatically from zoncoen/scenarigo to scenarigo/scenarigo

### DIFF
--- a/reporter/duration_unit_darwin_test.go
+++ b/reporter/duration_unit_darwin_test.go
@@ -6,4 +6,4 @@ package reporter
 
 import "time"
 
-const durationTestUnit = 1000 * time.Millisecond
+const durationTestUnit = 20 * time.Millisecond

--- a/reporter/duration_unit_test.go
+++ b/reporter/duration_unit_test.go
@@ -5,4 +5,4 @@ package reporter
 
 import "time"
 
-const durationTestUnit = 10 * time.Millisecond
+const durationTestUnit = 20 * time.Millisecond


### PR DESCRIPTION
When building a plugin, imports of the old module `github.com/zoncoen/scenarigo` will be automatically replaced with the new module `github.com/scenarigo/scenarigo`. To disable this migration behavior, use the `--skip-migration` option.