### PR TITLE
Introduce CurrentStep in context

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -21,6 +21,7 @@ type (
 	keyResponse         struct{}
 	keyYAMLNode         struct{}
 	keyEnabledColor     struct{}
+	keyCurrentStep      struct{}
 )
 
 // Context represents a scenarigo context.
@@ -278,6 +279,24 @@ func (c *Context) EnabledColor() bool {
 		return enabledColor
 	}
 	return false
+}
+
+// CurrentStep returns the current running step.
+func (c *Context) CurrentStep() *CurrentStep {
+	currentStep, ok := c.ctx.Value(keyCurrentStep{}).(*CurrentStep)
+	if ok {
+		return currentStep
+	}
+	return nil
+}
+
+// With CurrentStep returns a copy of c with current step.
+func (c *Context) WithCurrentStep(currentStep *CurrentStep) *Context {
+	return newContext(
+		context.WithValue(c.ctx, keyCurrentStep{}, currentStep),
+		c.reqCtx,
+		c.reporter,
+	)
 }
 
 // Run runs f as a subtest of c called name.

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -34,6 +34,62 @@ func TestContext(t *testing.T) {
 			t.Fatal("failed to get enabledColor")
 		}
 	})
+	t.Run("currentStep", func(t *testing.T) {
+		ctx := context.FromT(t)
+
+		// Test that CurrentStep returns nil initially
+		if ctx.CurrentStep() != nil {
+			t.Fatal("expected CurrentStep to be nil initially")
+		}
+
+		// Create a test CurrentStep
+		currentStep := &context.CurrentStep{
+			Index:       1,
+			ID:          "test-step",
+			Title:       "Test Step",
+			Description: "This is a test step",
+			Protocol:    "http",
+			Request: map[string]interface{}{
+				"method": "GET",
+				"url":    "https://example.com",
+			},
+		}
+
+		// Test WithCurrentStep
+		ctx = ctx.WithCurrentStep(currentStep)
+
+		// Test that CurrentStep returns the correct value
+		got := ctx.CurrentStep()
+		if got == nil {
+			t.Fatal("expected CurrentStep to return non-nil value")
+		}
+		if got.Index != currentStep.Index {
+			t.Errorf("expected Index %d but got %d", currentStep.Index, got.Index)
+		}
+		if got.ID != currentStep.ID {
+			t.Errorf("expected ID %q but got %q", currentStep.ID, got.ID)
+		}
+		if got.Title != currentStep.Title {
+			t.Errorf("expected Title %q but got %q", currentStep.Title, got.Title)
+		}
+		if got.Description != currentStep.Description {
+			t.Errorf("expected Description %q but got %q", currentStep.Description, got.Description)
+		}
+		if got.Protocol != currentStep.Protocol {
+			t.Errorf("expected Protocol %q but got %q", currentStep.Protocol, got.Protocol)
+		}
+
+		// Test that WithCurrentStep with nil sets CurrentStep to nil
+		ctx2 := ctx.WithCurrentStep(nil)
+		if ctx2.CurrentStep() != nil {
+			t.Fatal("expected WithCurrentStep(nil) to set CurrentStep to nil")
+		}
+
+		// Test that the original context is not modified
+		if ctx.CurrentStep() != currentStep {
+			t.Fatal("expected original context to remain unchanged")
+		}
+	})
 }
 
 func TestRunWithRetry(t *testing.T) {

--- a/context/current_step.go
+++ b/context/current_step.go
@@ -1,0 +1,27 @@
+package context
+
+import "time"
+
+// CurrentStep represents the current running step in the context.
+type CurrentStep struct {
+	Index int
+
+	// from github.com/scenarigo/scenarigo/schema.Step
+	ID                      string
+	Title                   string
+	Description             string
+	If                      string
+	ContinueOnError         bool
+	Vars                    map[string]any
+	Secrets                 map[string]any
+	Protocol                string
+	Request                 any
+	Expect                  any
+	Include                 string
+	Ref                     any
+	BindVars                map[string]any
+	BindSecrets             map[string]any
+	Timeout                 *time.Duration
+	PostTimeoutWaitingLimit *time.Duration
+	Retry                   any
+}

--- a/scenario.go
+++ b/scenario.go
@@ -66,7 +66,7 @@ func RunScenario(ctx *context.Context, s *schema.Scenario) *context.Context {
 	for idx, step := range s.Steps {
 		var stepCtx *context.Context
 		ok := context.RunWithRetry(scnCtx, step.Title, func(ctx *context.Context) {
-			stepCtx = ctx
+			stepCtx = ctx.WithCurrentStep(step.ToCurrentStep(idx))
 
 			// following steps are skipped if the previous step failed
 			if failed {

--- a/scenario_test.go
+++ b/scenario_test.go
@@ -45,6 +45,77 @@ steps:
 	}
 }
 
+func TestRunScenario_Context_CurrentStep(t *testing.T) {
+	path := createTempScenario(t, `
+steps:
+  - id: first-step
+    title: First Step
+    description: This is the first step
+    ref: '{{plugins.checkCurrentStep}}'
+  - id: second-step
+    title: Second Step
+    ref: '{{plugins.checkCurrentStep}}'
+  `)
+	scenarios, err := schema.LoadScenarios(path)
+	if err != nil {
+		t.Fatalf("failed to load scenario: %s", err)
+	}
+	if len(scenarios) != 1 {
+		t.Fatalf("unexpected scenario length: %d", len(scenarios))
+	}
+
+	var (
+		capturedSteps []context.CurrentStep
+		log           bytes.Buffer
+	)
+	ok := reporter.Run(func(rptr reporter.Reporter) {
+		ctx := context.New(rptr).WithPlugins(map[string]any{
+			"checkCurrentStep": plugin.StepFunc(func(ctx *context.Context, step *schema.Step) *context.Context {
+				currentStep := ctx.CurrentStep()
+				if currentStep == nil {
+					t.Fatal("CurrentStep is nil")
+				}
+				capturedSteps = append(capturedSteps, *currentStep)
+				return ctx
+			}),
+		})
+		RunScenario(ctx, scenarios[0])
+	}, reporter.WithWriter(&log))
+	if !ok {
+		t.Fatalf("scenario failed:\n%s", log.String())
+	}
+
+	// Verify we captured 2 steps
+	if len(capturedSteps) != 2 {
+		t.Fatalf("expected 2 captured steps, got %d", len(capturedSteps))
+	}
+
+	// Verify first step
+	if capturedSteps[0].Index != 0 {
+		t.Errorf("first step index: expected 0, got %d", capturedSteps[0].Index)
+	}
+	if capturedSteps[0].ID != "first-step" {
+		t.Errorf("first step ID: expected 'first-step', got %q", capturedSteps[0].ID)
+	}
+	if capturedSteps[0].Title != "First Step" {
+		t.Errorf("first step title: expected 'First Step', got %q", capturedSteps[0].Title)
+	}
+	if capturedSteps[0].Description != "This is the first step" {
+		t.Errorf("first step description: expected 'This is the first step', got %q", capturedSteps[0].Description)
+	}
+
+	// Verify second step
+	if capturedSteps[1].Index != 1 {
+		t.Errorf("second step index: expected 1, got %d", capturedSteps[1].Index)
+	}
+	if capturedSteps[1].ID != "second-step" {
+		t.Errorf("second step ID: expected 'second-step', got %q", capturedSteps[1].ID)
+	}
+	if capturedSteps[1].Title != "Second Step" {
+		t.Errorf("second step title: expected 'Second Step', got %q", capturedSteps[1].Title)
+	}
+}
+
 func createTempScenario(t *testing.T, scenario string) string {
 	t.Helper()
 	f, err := os.CreateTemp(t.TempDir(), "*.yaml")

--- a/schema/scenario.go
+++ b/schema/scenario.go
@@ -4,9 +4,11 @@ package schema
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/goccy/go-yaml/ast"
 
+	"github.com/scenarigo/scenarigo/context"
 	"github.com/scenarigo/scenarigo/errors"
 	"github.com/scenarigo/scenarigo/protocol"
 )
@@ -174,6 +176,29 @@ func (s *Step) UnmarshalYAML(unmarshal func(any) error) error {
 	s.Expect = builder
 
 	return nil
+}
+
+func (s *Step) ToCurrentStep(idx int) *context.CurrentStep {
+	return &context.CurrentStep{
+		Index:                   idx,
+		ID:                      s.ID,
+		Title:                   s.Title,
+		Description:             s.Description,
+		If:                      s.If,
+		ContinueOnError:         s.ContinueOnError,
+		Vars:                    s.Vars,
+		Secrets:                 s.Secrets,
+		Protocol:                s.Protocol,
+		Request:                 s.Request,
+		Expect:                  s.Expect,
+		Include:                 s.Include,
+		Ref:                     s.Ref,
+		BindVars:                s.Bind.Vars,
+		BindSecrets:             s.Bind.Secrets,
+		Timeout:                 (*time.Duration)(s.Timeout),
+		PostTimeoutWaitingLimit: (*time.Duration)(s.PostTimeoutWaitingLimit),
+		Retry:                   s.Retry,
+	}
 }
 
 // Bind represents bindings of variables.

--- a/schema/scenario_test.go
+++ b/schema/scenario_test.go
@@ -1,0 +1,135 @@
+package schema
+
+import (
+	"testing"
+	"time"
+
+	"github.com/scenarigo/scenarigo/assert"
+	"github.com/scenarigo/scenarigo/context"
+)
+
+func TestStep_ToCurrentStep(t *testing.T) {
+	mockInvoker := &mockInvoker{}
+	mockAssertionBuilder := &mockAssertionBuilder{}
+
+	timeout := Duration(5 * time.Second)
+	maxRetries := int(3)
+	postTimeoutWaitingLimit := Duration(10 * time.Second)
+
+	step := &Step{
+		ID:              "test-step-id",
+		Title:           "Test Step Title",
+		Description:     "This is a test step description",
+		If:              "{{vars.condition}}",
+		ContinueOnError: true,
+		Vars:            map[string]any{"var1": "value1", "var2": 123},
+		Secrets:         map[string]any{"secret1": "secretValue1"},
+		Protocol:        "http",
+		Request:         mockInvoker,
+		Expect:          mockAssertionBuilder,
+		Include:         "include-file.yaml",
+		Ref:             "{{plugins.testPlugin}}",
+		Bind: Bind{
+			Vars:    map[string]any{"bindVar1": "bindValue1"},
+			Secrets: map[string]any{"bindSecret1": "bindSecretValue1"},
+		},
+		Timeout:                 &timeout,
+		PostTimeoutWaitingLimit: &postTimeoutWaitingLimit,
+		Retry: &RetryPolicy{
+			Constant: &RetryPolicyConstant{
+				Interval:   (*Duration)(&timeout),
+				MaxRetries: &maxRetries,
+			},
+		},
+	}
+
+	idx := 5
+	currentStep := step.ToCurrentStep(idx)
+
+	if currentStep.Index != idx {
+		t.Errorf("Index: expected %d, got %d", idx, currentStep.Index)
+	}
+	if currentStep.ID != step.ID {
+		t.Errorf("ID: expected %q, got %q", step.ID, currentStep.ID)
+	}
+	if currentStep.Title != step.Title {
+		t.Errorf("Title: expected %q, got %q", step.Title, currentStep.Title)
+	}
+	if currentStep.Description != step.Description {
+		t.Errorf("Description: expected %q, got %q", step.Description, currentStep.Description)
+	}
+	if currentStep.If != step.If {
+		t.Errorf("If: expected %q, got %q", step.If, currentStep.If)
+	}
+	if currentStep.ContinueOnError != step.ContinueOnError {
+		t.Errorf("ContinueOnError: expected %v, got %v", step.ContinueOnError, currentStep.ContinueOnError)
+	}
+	if len(currentStep.Vars) != len(step.Vars) {
+		t.Errorf("Vars length: expected %d, got %d", len(step.Vars), len(currentStep.Vars))
+	}
+	for k, v := range step.Vars {
+		if currentStep.Vars[k] != v {
+			t.Errorf("Vars[%q]: expected %v, got %v", k, v, currentStep.Vars[k])
+		}
+	}
+	if len(currentStep.Secrets) != len(step.Secrets) {
+		t.Errorf("Secrets length: expected %d, got %d", len(step.Secrets), len(currentStep.Secrets))
+	}
+	for k, v := range step.Secrets {
+		if currentStep.Secrets[k] != v {
+			t.Errorf("Secrets[%q]: expected %v, got %v", k, v, currentStep.Secrets[k])
+		}
+	}
+	if currentStep.Protocol != step.Protocol {
+		t.Errorf("Protocol: expected %q, got %q", step.Protocol, currentStep.Protocol)
+	}
+	if currentStep.Request != step.Request {
+		t.Errorf("Request: expected %v, got %v", step.Request, currentStep.Request)
+	}
+	if currentStep.Expect != step.Expect {
+		t.Errorf("Expect: expected %v, got %v", step.Expect, currentStep.Expect)
+	}
+	if currentStep.Include != step.Include {
+		t.Errorf("Include: expected %q, got %q", step.Include, currentStep.Include)
+	}
+	if currentStep.Ref != step.Ref {
+		t.Errorf("Ref: expected %v, got %v", step.Ref, currentStep.Ref)
+	}
+	if len(currentStep.BindVars) != len(step.Bind.Vars) {
+		t.Errorf("BindVars length: expected %d, got %d", len(step.Bind.Vars), len(currentStep.BindVars))
+	}
+	for k, v := range step.Bind.Vars {
+		if currentStep.BindVars[k] != v {
+			t.Errorf("BindVars[%q]: expected %v, got %v", k, v, currentStep.BindVars[k])
+		}
+	}
+	if len(currentStep.BindSecrets) != len(step.Bind.Secrets) {
+		t.Errorf("BindSecrets length: expected %d, got %d", len(step.Bind.Secrets), len(currentStep.BindSecrets))
+	}
+	for k, v := range step.Bind.Secrets {
+		if currentStep.BindSecrets[k] != v {
+			t.Errorf("BindSecrets[%q]: expected %v, got %v", k, v, currentStep.BindSecrets[k])
+		}
+	}
+	if currentStep.Timeout == nil || *currentStep.Timeout != time.Duration(timeout) {
+		t.Errorf("Timeout: expected %v, got %v", time.Duration(timeout), currentStep.Timeout)
+	}
+	if currentStep.PostTimeoutWaitingLimit == nil || *currentStep.PostTimeoutWaitingLimit != time.Duration(postTimeoutWaitingLimit) {
+		t.Errorf("PostTimeoutWaitingLimit: expected %v, got %v", time.Duration(postTimeoutWaitingLimit), currentStep.PostTimeoutWaitingLimit)
+	}
+	if currentStep.Retry != step.Retry {
+		t.Errorf("Retry: expected %v, got %v", step.Retry, currentStep.Retry)
+	}
+}
+
+type mockInvoker struct{}
+
+func (m *mockInvoker) Invoke(ctx *context.Context) (*context.Context, any, error) {
+	return ctx, nil, nil
+}
+
+type mockAssertionBuilder struct{}
+
+func (m *mockAssertionBuilder) Build(ctx *context.Context) (assert.Assertion, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## What
This PR introduces `CurrentStep` in the context.
`CurrentStep` represents the content of the current running step in the scenario and its index.

## Why
- In the custom step func, we cannot get the index of the current runnning step.
  - So we cannot write `errors.ErrorPathf(fmt.Sprintf("steps[%d].~~~", stepIdx), ~~~)` in the step func to return proper error messages.
- In the custom protocol, we cannot get the content of current running step.
  - So we cannot use the information of step such as Title, Description, Vars,... etc for fancy logging.

This PR introduces `CurrentStep` in the context to handle the avobe problems.