### PR TITLE
fix(assert): prevent panic when actual value is nil

### DIFF
--- a/assert/compare.go
+++ b/assert/compare.go
@@ -139,6 +139,9 @@ func convert[T any](v any, t T) (T, error) {
 }
 
 func convertToType(v any, t reflect.Type) (any, error) {
+	if t == nil {
+		return nil, errors.Errorf("target type is nil")
+	}
 	rv := reflect.ValueOf(v)
 	if !rv.IsValid() {
 		return nil, errors.Errorf("value is invalid")

--- a/assert/equal_test.go
+++ b/assert/equal_test.go
@@ -3,6 +3,7 @@ package assert
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/scenarigo/scenarigo/errors"
@@ -93,6 +94,32 @@ func TestEqual(t *testing.T) {
 			}
 			if err := assertion.Assert(tc.ng); err == nil {
 				t.Errorf("expected error but no error")
+			}
+		})
+	}
+}
+
+func TestEqual_NilActual(t *testing.T) {
+	// Asserting a non-nil expected value against a nil actual value must
+	// return an error instead of panicking with
+	// "reflect: nil type passed to Type.ConvertibleTo".
+	tests := map[string]struct {
+		expected any
+	}{
+		"string":  {expected: "value"},
+		"int":     {expected: 1},
+		"struct":  {expected: struct{ A int }{A: 1}},
+		"pointer": {expected: func() *string { s := "v"; return &s }()},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("unexpected panic: %v", r)
+				}
+			}()
+			if err := Equal(tc.expected).Assert(nil); err == nil {
+				t.Fatal("expected error but no error")
 			}
 		})
 	}
@@ -204,6 +231,16 @@ func TestConvert(t *testing.T) {
 			}
 		})
 	}
+	t.Run("convertToType with nil target type", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("unexpected panic: %v", r)
+			}
+		}()
+		if _, err := convertToType("v", reflect.Type(nil)); err == nil {
+			t.Fatal("expected error but no error")
+		}
+	})
 	t.Run("convertToBigInt", func(t *testing.T) {
 		if _, err := convertToBigInt("bad value"); err == nil {
 			t.Fatal("expected error but not eror")


### PR DESCRIPTION
## Summary

- `Equal(non-nil).Assert(nil)` panicked with `reflect: nil type passed to Type.ConvertibleTo` because `reflect.TypeOf(nil)` returned a nil `reflect.Type` that was passed into `convertToType` (`assert/equal.go:88`), which then called `rv.Type().ConvertibleTo(nil)`.
- Guard `convertToType` against a nil target type so it returns an error instead of panicking. The error is swallowed by the caller and surfaces as the usual `expected ... but got <nil>` message.
- Added regression tests for `Equal(...).Assert(nil)` covering string / int / struct / pointer expectations, plus a direct unit test on `convertToType` to keep the inner guard honest.

## Test plan

- [x] `go test ./assert/...`