### PR TITLE
fix(errors): fix MultiPathError.wrapf panic; ignore nil in Errors

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -63,10 +63,16 @@ func ErrorPath(path, message string) error {
 
 // Errors create MultiPathError by error instances.
 func Errors(errs ...error) error {
-	if len(errs) == 0 {
+	nonNilErrs := make([]error, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			nonNilErrs = append(nonNilErrs, err)
+		}
+	}
+	if len(nonNilErrs) == 0 {
 		return nil
 	}
-	return &MultiPathError{Errs: errs}
+	return &MultiPathError{Errs: nonNilErrs}
 }
 
 // Wrap wrap error while paying attention to PathError and MultiPathError.
@@ -316,7 +322,7 @@ func (e *MultiPathError) replacePath(old, newPath string) {
 func (e *MultiPathError) wrapf(message string, args ...any) {
 	for idx, err := range e.Errs {
 		var pathErr Error
-		if errors.As(err, &e) {
+		if errors.As(err, &pathErr) {
 			pathErr.wrapf(message, args...)
 		} else {
 			e.Errs[idx] = Wrapf(err, message, args...)

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -83,6 +83,19 @@ func TestErrors(t *testing.T) {
 			t.Errorf("not nil: %v", err)
 		}
 	})
+
+	t.Run("should ignore nil errors", func(t *testing.T) {
+		if err := Errors(nil); err != nil {
+			t.Errorf("not nil: %v", err)
+		}
+		err := Errors(nil, errors.New("message"), nil)
+		if err == nil {
+			t.Fatal("no error")
+		}
+		if got, expect := err.Error(), "1 error occurred: message"; got != expect {
+			t.Fatalf("unexpected error message: %s", got)
+		}
+	})
 	t.Run("should be wrapped by MultiPathError", func(t *testing.T) {
 		err := Errors(errors.New("a"), errors.New("b"))
 		if err == nil {
@@ -366,6 +379,22 @@ unexpected error: invalid b
 			t.Errorf("stdout differs:\n%s", dmp.DiffPrettyText(diffs))
 		}
 	})
+}
+
+func TestMultiPathErrorWithNestedMultiPathError(t *testing.T) {
+	err := Wrap(
+		Errors(
+			ErrorPath("a", "message1"),
+			Errors(
+				ErrorPath("b", "message2"),
+				errors.New("message3"),
+			),
+		),
+		"wrapped",
+	)
+	if got, expect := err.Error(), "2 errors occurred: .a: wrapped: message1\n2 errors occurred: .b: wrapped: message2\nwrapped: message3"; got != expect {
+		t.Fatalf("unexpected error message: %s", got)
+	}
 }
 
 func TestReplacePath(t *testing.T) {


### PR DESCRIPTION
## Summary


### Bug fix — `MultiPathError.wrapf`

It passed the receiver (`&e`) to `errors.As` instead of `&pathErr`, so `pathErr`
was never assigned and `pathErr.wrapf(...)` panicked with a nil-pointer
dereference. This happened when wrapping a `MultiPathError` that contained a
nested `MultiPathError`, e.g. `Wrap(Errors(ErrorPath(...), Errors(...)), "...")`.
Fixed by passing `&pathErr`.

### Improvement — `Errors()`

`Errors()` now skips nil errors before building the result, so `Errors(nil)`
returns `nil` instead of a non-nil error and `Errors(err, nil)` no longer
carries a nil element.

## Test plan

- [x] Added tests for nil handling and the nested-error panic
- [x] `go test ./errors/ ./assert/ ./schema/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)