### PR TITLE
fix(plugin): normalize path before using it as the cache key

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -28,7 +28,7 @@ func Open(path string) (Plugin, error) {
 		}
 		path = abs
 	}
-	filepath.Clean(path)
+	path = filepath.Clean(path)
 	m.Lock()
 	defer m.Unlock()
 	if p, ok := cache[path]; ok {


### PR DESCRIPTION
## Summary

- `filepath.Clean(path)` was called without using its return value, so `path` was never normalized before being used as the key for the plugin cache (`cache map[string]Plugin` in `plugin/plugin.go`). `filepath.Clean` returns a cleaned path rather than mutating in place.
- Assign the result back (`path = filepath.Clean(path)`) so logically-identical paths resolve to a single cache entry, keeping `Open` consistent under concurrent use.

## Test plan

- [x] `go test ./plugin/`