### PR TITLE
test(reporter): make TestRun_NilPanic Go-version independent

### DIFF
--- a/reporter/reporter_non_race_test.go
+++ b/reporter/reporter_non_race_test.go
@@ -34,7 +34,7 @@ func TestRun_NilPanic(t *testing.T) {
 					{},
 					{
 						Failed: true,
-						Logs:   []string{"panic called with nil argument"},
+						Logs:   []string{(&runtime.PanicNilError{}).Error()},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

`TestRun_NilPanic` hard-coded the expected log message `"panic called with nil argument"`. Go's `runtime.PanicNilError.Error()` gained a `"runtime error: "` prefix ([golang/go#63813](https://github.com/golang/go/issues/63813)), so on Go tip (go1.27-devel) the message is now `"runtime error: panic called with nil argument"`, which broke the `test on tip` workflow.

This derives the expected message from `(&runtime.PanicNilError{}).Error()` so the test stays correct on every Go version.

## Test plan

- [x] `go test ./reporter/` on Go 1.26.0 (stable) — pass
- [x] `gotip test ./reporter/` on go1.27-devel — pass
- [x] Confirmed the test fails on tip without this change
