### PR TITLE
feat(template): support non-literal index expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,23 @@ vars:
   text: 'foo-{{"bar"}}-baz' # text: 'foo-bar-baz'
 ```
 
+You can access an element of an array or a map by an index expression. The index accepts an arbitrary expression that evaluates to an integer (for arrays) or a string (for maps). A map value whose key is a valid identifier can also be accessed with selector notation (`vars.map.foo` is equivalent to `vars.map["foo"]`); the string index is useful when the key is held in a variable or is not a valid identifier (e.g. contains dots or hyphens).
+
+```yaml
+vars:
+  array: [a, b, c]
+  index: 1
+  map:
+    foo.bar: FOO
+  key: foo.bar
+steps:
+- vars:
+    first: '{{vars.array[0]}}'            # first: a
+    second: '{{vars.array[vars.index]}}'  # second: b
+    literal: '{{vars.map["foo.bar"]}}'    # literal: FOO
+    byKey: '{{vars.map[vars.key]}}'       # byKey: FOO
+```
+
 ### Syntax
 
 The grammar of the template is defined below, using `|` for alternatives, `[]` for optional, `{}` for repeated, `()` for grouping, and `...` for character range.
@@ -1361,7 +1378,7 @@ UnaryExpr       = [UnaryOp] (
 UnaryOp         = "!" | "-"
 ParenExpr       = "(" Expr ")"
 SelectorExpr    = Expr "." IDENT
-IndexExpr       = Expr "[" INT "]"
+IndexExpr       = Expr "[" Expr "]"
 CallExpr        = Expr "(" [Expr {"," Expr}] ")"
 BinaryExpr      = Expr BinaryOp Expr
 BinaryOp        = "+" | "-" | "*" | "/" | "%" |

--- a/README.md
+++ b/README.md
@@ -1365,6 +1365,8 @@ vars:
 {{vars.map[vars.key]}}       # FOO
 ```
 
+The base of an index expression must be a variable reference; the result of a function call can not be indexed. A number decoded from a JSON response body is always an index, so a map whose keys are numeric strings must be accessed by a string (e.g. `{{vars.map[string(response.body.id)]}}`).
+
 ### Syntax
 
 The grammar of the template is defined below, using `|` for alternatives, `[]` for optional, `{}` for repeated, `()` for grouping, and `...` for character range.

--- a/README.md
+++ b/README.md
@@ -1356,12 +1356,13 @@ vars:
   map:
     foo.bar: FOO
   key: foo.bar
-steps:
-- vars:
-    first: '{{vars.array[0]}}'            # first: a
-    second: '{{vars.array[vars.index]}}'  # second: b
-    literal: '{{vars.map["foo.bar"]}}'    # literal: FOO
-    byKey: '{{vars.map[vars.key]}}'       # byKey: FOO
+```
+
+```
+{{vars.array[0]}}            # a
+{{vars.array[vars.index]}}   # b
+{{vars.map["foo.bar"]}}      # FOO
+{{vars.map[vars.key]}}       # FOO
 ```
 
 ### Syntax

--- a/template/lookup.go
+++ b/template/lookup.go
@@ -2,8 +2,10 @@ package template
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"reflect"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/zoncoen/query-go"
@@ -93,6 +95,18 @@ func (t *Template) appendIndexQuery(ctx context.Context, q *query.Query, expr as
 	v, err := t.executeExpr(ctx, expr, data)
 	if err != nil {
 		return nil, err
+	}
+	// JSON numbers are decoded as json.Number, whose kind is string. Interpret
+	// them as integers so that an index taken from a response body works.
+	if n, ok := v.(json.Number); ok {
+		i, err := n.Int64()
+		if err != nil {
+			if errors.Is(err, strconv.ErrRange) {
+				return nil, errors.Errorf("index %s overflows int", n.String())
+			}
+			return nil, errors.Errorf("expected an integer or string index but got %s", n.String())
+		}
+		v = i
 	}
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {

--- a/template/lookup.go
+++ b/template/lookup.go
@@ -2,30 +2,30 @@ package template
 
 import (
 	"context"
-	"strconv"
+	"math"
+	"reflect"
 
 	"github.com/pkg/errors"
 	"github.com/zoncoen/query-go"
 
 	"github.com/scenarigo/scenarigo/internal/queryutil"
 	"github.com/scenarigo/scenarigo/template/ast"
-	"github.com/scenarigo/scenarigo/template/token"
 )
 
 type notDefinedError struct {
 	error
 }
 
-func lookup(ctx context.Context, node ast.Node, data any) (any, error) {
-	v, err := extract(ctx, node, data)
+func (t *Template) lookup(ctx context.Context, node ast.Node, data any) (any, error) {
+	v, err := t.extract(ctx, node, data)
 	if err != nil {
 		return nil, err
 	}
 	return Execute(ctx, v, data)
 }
 
-func extract(ctx context.Context, node ast.Node, data any) (any, error) {
-	q, err := buildQuery(queryutil.New(), node)
+func (t *Template) extract(ctx context.Context, node ast.Node, data any) (any, error) {
+	q, err := t.buildQuery(ctx, queryutil.New(), node, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create query from AST")
 	}
@@ -65,31 +65,58 @@ func extract(ctx context.Context, node ast.Node, data any) (any, error) {
 	return v, nil
 }
 
-func buildQuery(q *query.Query, node ast.Node) (*query.Query, error) {
+func (t *Template) buildQuery(ctx context.Context, q *query.Query, node ast.Node, data any) (*query.Query, error) {
 	var err error
 	switch n := node.(type) {
 	case *ast.Ident:
 		return q.Key(n.Name), nil
 	case *ast.SelectorExpr:
-		q, err = buildQuery(q, n.X)
+		q, err = t.buildQuery(ctx, q, n.X, data)
 		if err != nil {
 			return nil, err
 		}
 		return q.Key(n.Sel.Name), nil
 	case *ast.IndexExpr:
-		i, ok := n.Index.(*ast.BasicLit)
-		if !ok || i.Kind != token.INT {
-			return nil, errors.Errorf(`expected int but "%s"`, i.Kind.String())
-		}
-		idx, err := strconv.Atoi(i.Value)
-		if err != nil {
-			return nil, errors.Errorf(`expected int but "%s"`, i.Value)
-		}
-		q, err = buildQuery(q, n.X)
+		q, err = t.buildQuery(ctx, q, n.X, data)
 		if err != nil {
 			return nil, err
 		}
-		return q.Index(idx), nil
+		return t.appendIndexQuery(ctx, q, n.Index, data)
 	}
 	return nil, errors.Errorf(`unknown node "%T"`, node)
+}
+
+// appendIndexQuery evaluates the index expression and appends the
+// corresponding extractor to q: an integer extracts by index, a string
+// extracts by key.
+func (t *Template) appendIndexQuery(ctx context.Context, q *query.Query, expr ast.Expr, data any) (*query.Query, error) {
+	v, err := t.executeExpr(ctx, expr, data)
+	if err != nil {
+		return nil, err
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i := rv.Int()
+		if i < 0 {
+			return nil, errors.Errorf("index must not be negative but got %d", i)
+		}
+		if i > math.MaxInt {
+			return nil, errors.Errorf("index %d overflows int", i)
+		}
+		return q.Index(int(i)), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		u := rv.Uint()
+		if u > math.MaxInt {
+			return nil, errors.Errorf("index %d overflows int", u)
+		}
+		return q.Index(int(u)), nil
+	case reflect.String:
+		return q.Key(rv.String()), nil
+	default:
+		if v == nil {
+			return nil, errors.New("expected an integer or string index but got nil")
+		}
+		return nil, errors.Errorf("expected an integer or string index but got %T", v)
+	}
 }

--- a/template/lookup.go
+++ b/template/lookup.go
@@ -29,7 +29,7 @@ func (t *Template) lookup(ctx context.Context, node ast.Node, data any) (any, er
 func (t *Template) extract(ctx context.Context, node ast.Node, data any) (any, error) {
 	q, err := t.buildQuery(ctx, queryutil.New(), node, data)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create query from AST")
+		return nil, err
 	}
 
 	f, err := q.Extract(functions)
@@ -85,7 +85,7 @@ func (t *Template) buildQuery(ctx context.Context, q *query.Query, node ast.Node
 		}
 		return t.appendIndexQuery(ctx, q, n.Index, data)
 	}
-	return nil, errors.Errorf(`unknown node "%T"`, node)
+	return nil, errors.Errorf(`failed to create query from AST: unknown node "%T"`, node)
 }
 
 // appendIndexQuery evaluates the index expression and appends the

--- a/template/template.go
+++ b/template/template.go
@@ -89,11 +89,11 @@ func (t *Template) executeExpr(ctx context.Context, expr ast.Expr, data any) (an
 	case *ast.ConditionalExpr:
 		return t.executeConditionalExpr(ctx, e, data)
 	case *ast.Ident:
-		return lookup(ctx, e, data)
+		return t.lookup(ctx, e, data)
 	case *ast.SelectorExpr:
-		return lookup(ctx, e, data)
+		return t.lookup(ctx, e, data)
 	case *ast.IndexExpr:
-		return lookup(ctx, e, data)
+		return t.lookup(ctx, e, data)
 	case *ast.CallExpr:
 		return t.executeFuncCall(ctx, e, data)
 	case *ast.LeftArrowExpr:
@@ -345,7 +345,7 @@ func (t *Template) executeBinaryOperation(op token.Token, x, y val.Value, yExpr 
 func (t *Template) executeCoalescingExpr(ctx context.Context, e *ast.BinaryExpr, data any) (any, error) {
 	switch e.X.(type) {
 	case *ast.Ident, *ast.SelectorExpr, *ast.IndexExpr:
-		extracted, err := extract(ctx, e.X, data)
+		extracted, err := t.extract(ctx, e.X, data)
 		if err != nil {
 			var notDefined notDefinedError
 			if errors.As(err, &notDefined) {
@@ -447,7 +447,7 @@ func (t *Template) executeFuncCall(ctx context.Context, call *ast.CallExpr, data
 		if err != nil {
 			return nil, err
 		}
-		v, err := lookup(ctx, selector.Sel, x)
+		v, err := t.lookup(ctx, selector.Sel, x)
 		if err == nil {
 			fn = reflect.ValueOf(v)
 		} else {
@@ -780,7 +780,7 @@ func (t *Template) executeLeftArrowExpr(ctx context.Context, e *ast.LeftArrowExp
 func (t *Template) executeDefinedExpr(ctx context.Context, e *ast.DefinedExpr, data any) (any, error) {
 	switch e.Arg.(type) {
 	case *ast.Ident, *ast.SelectorExpr, *ast.IndexExpr:
-		if _, err := extract(ctx, e.Arg, data); err != nil {
+		if _, err := t.extract(ctx, e.Arg, data); err != nil {
 			var notDefined notDefinedError
 			if errors.As(err, &notDefined) {
 				return false, nil

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
@@ -349,8 +350,11 @@ func TestTemplate_Execute_IndexExpr(t *testing.T) {
 				"foo":         "FOO",
 				"foo.bar-baz": "QUX",
 			},
-			"key":  "foo",
-			"keys": map[string]string{"ref": "foo"},
+			"key":     "foo",
+			"keys":    map[string]string{"ref": "foo"},
+			"jsonNum": json.Number("2"),
+			"jsonFlt": json.Number("1.5"),
+			"jsonBig": json.Number("9223372036854775808"),
 		},
 	}
 	tests := map[string]executeTestCase{
@@ -366,6 +370,11 @@ func TestTemplate_Execute_IndexExpr(t *testing.T) {
 		},
 		"index by unsigned integer variable": {
 			str:    "{{vars.array[vars.uindex]}}",
+			data:   data,
+			expect: "c",
+		},
+		"index by JSON number variable": {
+			str:    "{{vars.array[vars.jsonNum]}}",
 			data:   data,
 			expect: "c",
 		},
@@ -413,6 +422,16 @@ func TestTemplate_Execute_IndexExpr(t *testing.T) {
 			str:         "{{vars.array[1.5]}}",
 			data:        data,
 			expectError: "expected an integer or string index but got float64",
+		},
+		"non-integer JSON number index": {
+			str:         "{{vars.array[vars.jsonFlt]}}",
+			data:        data,
+			expectError: "expected an integer or string index but got 1.5",
+		},
+		"out of range JSON number index": {
+			str:         "{{vars.array[vars.jsonBig]}}",
+			data:        data,
+			expectError: "index 9223372036854775808 overflows int",
 		},
 		"bool index": {
 			str:         "{{vars.array[true]}}",

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -339,6 +339,115 @@ func TestTemplate_Execute(t *testing.T) {
 	runExecute(t, tests)
 }
 
+func TestTemplate_Execute_IndexExpr(t *testing.T) {
+	data := map[string]any{
+		"vars": map[string]any{
+			"array":  []string{"a", "b", "c"},
+			"index":  1,
+			"uindex": uint(2),
+			"map": map[string]string{
+				"foo":         "FOO",
+				"foo.bar-baz": "QUX",
+			},
+			"key":  "foo",
+			"keys": map[string]string{"ref": "foo"},
+		},
+	}
+	tests := map[string]executeTestCase{
+		"integer literal index": {
+			str:    "{{vars.array[1]}}",
+			data:   data,
+			expect: "b",
+		},
+		"index by variable": {
+			str:    "{{vars.array[vars.index]}}",
+			data:   data,
+			expect: "b",
+		},
+		"index by unsigned integer variable": {
+			str:    "{{vars.array[vars.uindex]}}",
+			data:   data,
+			expect: "c",
+		},
+		"index by expression": {
+			str:    "{{vars.array[1+1]}}",
+			data:   data,
+			expect: "c",
+		},
+		"key by string literal": {
+			str:    `{{vars.map["foo"]}}`,
+			data:   data,
+			expect: "FOO",
+		},
+		"key by string literal containing special characters": {
+			str:    `{{vars.map["foo.bar-baz"]}}`,
+			data:   data,
+			expect: "QUX",
+		},
+		"key by variable": {
+			str:    "{{vars.map[vars.key]}}",
+			data:   data,
+			expect: "FOO",
+		},
+		"key by nested index expression": {
+			str:    `{{vars.map[vars.keys["ref"]]}}`,
+			data:   data,
+			expect: "FOO",
+		},
+		"key not found": {
+			str:         `{{vars.map["missing"]}}`,
+			data:        data,
+			expectError: `".vars.map.missing" not found`,
+		},
+		"index out of range": {
+			str:         "{{vars.array[3]}}",
+			data:        data,
+			expectError: `".vars.array[3]" not found`,
+		},
+		"negative index": {
+			str:         "{{vars.array[-1]}}",
+			data:        data,
+			expectError: "index must not be negative but got -1",
+		},
+		"float index": {
+			str:         "{{vars.array[1.5]}}",
+			data:        data,
+			expectError: "expected an integer or string index but got float64",
+		},
+		"bool index": {
+			str:         "{{vars.array[true]}}",
+			data:        data,
+			expectError: "expected an integer or string index but got bool",
+		},
+		"nil index": {
+			str:         "{{vars.array[nil]}}",
+			data:        data,
+			expectError: "expected an integer or string index but got nil",
+		},
+		"undefined variable index": {
+			str:         "{{vars.map[vars.missing]}}",
+			data:        data,
+			expectError: `".vars.missing" not found`,
+		},
+		"undefined variable index with coalescing operator": {
+			str:    `{{vars.map[vars.missing] ?? "default"}}`,
+			data:   data,
+			expect: "default",
+		},
+		"defined() with index by variable": {
+			str:    "{{defined(vars.map[vars.key])}}",
+			data:   data,
+			expect: true,
+		},
+		"defined() with undefined variable index": {
+			str:    "{{defined(vars.map[vars.missing])}}",
+			data:   data,
+			expect: false,
+		},
+	}
+	runExecute(t, tests)
+}
+
 func TestTemplate_Execute_UnaryExpr(t *testing.T) {
 	tests := map[string]executeTestCase{
 		"!true": {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -444,9 +444,11 @@ func TestTemplate_Execute_IndexExpr(t *testing.T) {
 			expectError: "expected an integer or string index but got nil",
 		},
 		"undefined variable index": {
-			str:         "{{vars.map[vars.missing]}}",
-			data:        data,
-			expectError: `".vars.missing" not found`,
+			str:  "{{vars.map[vars.missing]}}",
+			data: data,
+			// the failure of the index expression is reported as-is, not as a
+			// failure to build the query
+			expectError: `failed to execute: {{vars.map[vars.missing]}}: ".vars.missing" not found`,
 		},
 		"undefined variable index with coalescing operator": {
 			str:    `{{vars.map[vars.missing] ?? "default"}}`,


### PR DESCRIPTION
## Summary

Evaluate the index expression of an `IndexExpr` at execution time instead of accepting only integer literals. An integer result extracts by index and a string result extracts by key, so the following now work (fixes #796):

| Template | Result |
|---|---|
| `{{vars.array[vars.index]}}` | element at the evaluated index |
| `{{vars.map["foo"]}}` | value by string literal key |
| `{{vars.map[vars.key]}}` | value by key held in a variable |
| `{{vars.array[1+1]}}` | element at the computed index |

String keys are useful when the key is not a valid identifier (e.g. contains dots or hyphens) or is held in a variable; for identifier keys, the bracket form is equivalent to the selector notation (`vars.map.foo`), which is now documented.

## Implementation

- `lookup` / `extract` / `buildQuery` become methods on `*Template` so that the index expression can be evaluated with `executeExpr` (all callers already had the receiver in scope; package-internal change).
- The new `appendIndexQuery` dispatches on the evaluated value: integer kinds → `q.Index(i)`, strings → `q.Key(s)`. Negative indices and values overflowing `int` are rejected explicitly, and non-integer/non-string results (float, bool, nil) report a meaningful error.
- `??` and `defined()` keep their semantics: an undefined variable inside an index expression propagates as `notDefinedError`, so `{{vars.map[vars.missing] ?? "default"}}` falls back and `{{defined(vars.map[vars.missing])}}` is false (pinned by tests).
- README: grammar updated to `IndexExpr = Expr "[" Expr "]"` with a worked example.

## Bug fix included

The old error path dereferenced a nil `*ast.BasicLit` when the index was not a basic literal, so `{{vars.array[vars.index]}}` failed with a recovered `failed to execute: panic: runtime error: invalid memory address or nil pointer dereference` instead of a meaningful message. The rewrite removes that path entirely.

## Tests

New `TestTemplate_Execute_IndexExpr` table (17 cases) covering every example from the issue plus special-character keys, nested index expressions, unsigned indices, out-of-range/not-found message compatibility, and the error cases above.

Note: negative indices are rejected for now; once the repo adopts query-go v1.5.0 (negative index support upstream), the guard can be relaxed to RFC 9535 from-the-end semantics as a follow-up.